### PR TITLE
LateInitializationError: Field '_updatePosition' has not been initialized.

### DIFF
--- a/lib/src/swipe_detector.dart
+++ b/lib/src/swipe_detector.dart
@@ -162,6 +162,7 @@ class _SwipeDetectorState extends State<SwipeDetector> {
       behavior: widget.behavior,
       onPanStart: (details) {
         _startPosition = details.globalPosition;
+        _updatePosition = details.globalPosition;
       },
       onPanUpdate: (details) {
         _updatePosition = details.globalPosition;


### PR DESCRIPTION
This PR is for fixing the issue bellow. It happens many times on my app.

```
════════ Exception caught by gesture ═══════════════════════════════════════════
The following LateError was thrown while handling a gesture:
LateInitializationError: Field '_updatePosition@39331832' has not been initialized.

When the exception was thrown, this was the stack
#0      _SwipeDetectorState._updatePosition (package:flutter_swipe_detector/src/swipe_detector.dart)
#1      _SwipeDetectorState._calculateAndExecute
#2      _SwipeDetectorState.build.<anonymous closure>
#3      DragGestureRecognizer._checkEnd.<anonymous closure>
#4      GestureRecognizer.invokeCallback
#5      DragGestureRecognizer._checkEnd
#6      DragGestureRecognizer.didStopTrackingLastPointer
#7      OneSequenceGestureRecognizer.stopTrackingPointer
#8      DragGestureRecognizer._giveUpPointer
#9      DragGestureRecognizer.handleEvent
#10     PointerRouter._dispatch
#11     PointerRouter._dispatchEventToRoutes.<anonymous closure>
#12     _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:614:13)
#13     PointerRouter._dispatchEventToRoutes
#14     PointerRouter.route
#15     GestureBinding.handleEvent
#16     GestureBinding.dispatchEvent
#17     RendererBinding.dispatchEvent
#18     GestureBinding._handlePointerEventImmediately
#19     GestureBinding.handlePointerEvent
#20     GestureBinding._flushPointerEventQueue
#21     GestureBinding._handlePointerDataPacket
#22     _invoke1 (dart:ui/hooks.dart:164:13)
#23     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:361:7)
#24     _dispatchPointerDataPacket (dart:ui/hooks.dart:91:31)
Handler: "onEnd"
Recognizer: PanGestureRecognizer#af55a
    debugOwner: GestureDetector
    start behavior: start
════════════════════════════════════════════════════════════════════════════════
```